### PR TITLE
DARAJA: remove emitting loading twice

### DIFF
--- a/daraja/src/main/java/com/github/daraja/driver/DarajaDriver.kt
+++ b/daraja/src/main/java/com/github/daraja/driver/DarajaDriver.kt
@@ -56,15 +56,11 @@ class DarajaDriver(private val consumerKey: String, private val consumerSecret: 
                 )
             }
             is Resource.Success -> {
-                emit(
-                    Resource.Loading(
-                        accessTokenResult.data?.let {
-                            darajaStkPushState.copy(
-                                accessToken = it.accessToken
-                            )
-                        }
+                accessTokenResult.data?.let {
+                    darajaStkPushState.copy(
+                        accessToken = it.accessToken
                     )
-                )
+                }
 
                 when (val sendOtpResult =
                     accessTokenResult.data?.let {


### PR DESCRIPTION
I noticed a mistake of emitting `Loading` twice, other than just `copying` the access token inside the state.