### PR TITLE
Optimize timeout settings

### DIFF
--- a/daraja/src/main/java/com/github/daraja/utils/Constants.kt
+++ b/daraja/src/main/java/com/github/daraja/utils/Constants.kt
@@ -16,7 +16,7 @@
 package com.github.daraja.utils
 
 internal object Constants {
-    const val CONNECT_TIMEOUT = 60 * 1000
-    const val READ_TIMEOUT = 60 * 1000
+    const val CONNECT_TIMEOUT = 45 * 1000
+    const val READ_TIMEOUT = 45 * 1000
     const val WRITE_TIMEOUT = 60 * 1000
 }


### PR DESCRIPTION
Reduced the connection and read timeouts from 60 to 45 seconds to enhance the responsiveness and provide quicker feedback in case of network issues (maybe we can lower this to even 40 seconds 😅).

@Carrieukie @joelkanyi @Breens-Mbaka 
