### PR TITLE
update github actions to v4 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew publishToMavenLocal
 
       - name: Upload a Build Artifact (APK)
-        uses: actions/upload-artifact@4
+        uses: actions/upload-artifact@3
         with:
           name: app
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew publishToMavenLocal
 
       - name: Upload a Build Artifact (APK)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2.2.4
         with:
           name: app
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Access API Keys
         run: |
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew publishToMavenLocal
 
       - name: Upload a Build Artifact (APK)
-        uses: actions/upload-artifact@v4.1.8
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew publishToMavenLocal
 
       - name: Upload a Build Artifact (APK)
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4.1.8
         with:
           name: app
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew publishToMavenLocal
 
       - name: Upload a Build Artifact (APK)
-        uses: actions/upload-artifact@3
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew publishToMavenLocal
 
       - name: Upload a Build Artifact (APK)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: app
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-          
+
       - name: Access API Keys
         run: |
             touch local.properties
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew publishToMavenLocal
 
       - name: Upload a Build Artifact (APK)
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@4
         with:
           name: app
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
+          distribution: 'temurin'
 
       - name: Access API Keys
         run: |


### PR DESCRIPTION
I noted a build failure resulting from the deprecated version 2 of the GitHub Actions. I updated the CI configuration to use version 4 of each action and updated the Java JDK to version 4.

@Carrieukie 